### PR TITLE
Need to use `HolderLookup.Provider#createSerializationContext`

### DIFF
--- a/common/src/main/java/net/favouriteless/modopedia/api/datagen/providers/ContentSetProvider.java
+++ b/common/src/main/java/net/favouriteless/modopedia/api/datagen/providers/ContentSetProvider.java
@@ -54,7 +54,7 @@ public abstract class ContentSetProvider implements DataProvider {
         final Set<String> categories = Sets.newHashSet();
 
         final List<CompletableFuture<?>> futures = new ArrayList<>();
-        RegistryOps<JsonElement> ops = RegistryOps.create(JsonOps.INSTANCE, registries);
+        RegistryOps<JsonElement> ops = registries.createSerializationContext(JsonOps.INSTANCE);
 
         buildEntries(registries, (id, builder) -> {
             if(!entries.add(id))

--- a/common/src/main/java/net/favouriteless/modopedia/book/loading/BookContentLoader.java
+++ b/common/src/main/java/net/favouriteless/modopedia/book/loading/BookContentLoader.java
@@ -152,7 +152,7 @@ public class BookContentLoader {
     private static List<Page> loadPages(String entry, JsonArray array, Book book, String language, Level level) {
         List<Page> out = new ArrayList<>();
 
-        final RegistryOps<JsonElement> ops = RegistryOps.create(JsonOps.INSTANCE, level.registryAccess());
+        final RegistryOps<JsonElement> ops = level.registryAccess().createSerializationContext(JsonOps.INSTANCE);
         for(JsonElement element : array) {
             try {
                 PageImpl page = new PageImpl(loadPageComponentHolder(entry, element.getAsJsonObject(), language, out.size(), ops));


### PR DESCRIPTION
Actually fix what the datagen refactor was meant to do (apparently some lookups wish to create RegistryOps in different ways)