### PR TITLE
Allow landing pages to use click event format codes as well as hover event codes

### DIFF
--- a/common/src/main/java/net/favouriteless/modopedia/client/screens/books/MultiPageBookScreen.java
+++ b/common/src/main/java/net/favouriteless/modopedia/client/screens/books/MultiPageBookScreen.java
@@ -80,6 +80,23 @@ public abstract class MultiPageBookScreen extends BookScreen {
     }
 
     @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if (super.mouseClicked(mouseX, mouseY, button))
+            return true;
+        for(int i = 0; i < texture.pages().size() && leftPage+i < pages.size(); i++) {
+            ScreenPage page = pages.get(leftPage + i);
+            Rectangle details = texture.pages().get(i);
+
+            int xShift = leftPos + details.u();
+            int yShift = topPos + details.v();
+            if (page.mouseClicked(details, mouseX - xShift, mouseY - yShift, button)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public void tick() {
         super.tick();
         for(ScreenPage page : pages) {

--- a/common/src/main/java/net/favouriteless/modopedia/client/screens/books/book_screen_pages/FormattedTextPage.java
+++ b/common/src/main/java/net/favouriteless/modopedia/client/screens/books/book_screen_pages/FormattedTextPage.java
@@ -28,6 +28,13 @@ public class FormattedTextPage extends ScreenPage {
         }
     }
 
-
-
+    @Override
+    public boolean mouseClicked(Rectangle rectangle, double mouseX, double mouseY, int button) {
+        for (TextChunk chunk : landingText) {
+            if (chunk.mouseClicked(this.parent.getScreen(), mouseX - textX, mouseY - textY, button)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/common/src/main/java/net/favouriteless/modopedia/client/screens/books/book_screen_pages/LandingScreenPage.java
+++ b/common/src/main/java/net/favouriteless/modopedia/client/screens/books/book_screen_pages/LandingScreenPage.java
@@ -58,12 +58,20 @@ public class LandingScreenPage extends FormattedTextPage {
         }
 
         poseStack.pushPose();
-        poseStack.translate(0, (backer.y() + backer.height()) - rectangle.v(), 0);
+        final var yShift = (backer.y() + backer.height()) - rectangle.v();
+        poseStack.translate(0, yShift, 0);
 
-        super.render(graphics, poseStack, rectangle, mouseX, mouseY, partialTick);
+        super.render(graphics, poseStack, rectangle, mouseX, mouseY - yShift, partialTick);
 
         poseStack.popPose();
 
     }
 
+    @Override
+    public boolean mouseClicked(Rectangle rectangle, double mouseX, double mouseY, int button) {
+        BookTexture texture = parent.getBookTexture();
+        FixedRectangle backer = texture.titleBacker();
+        final var yShift = (backer.y() + backer.height()) - rectangle.v();
+        return super.mouseClicked(rectangle, mouseX, mouseY - yShift, button);
+    }
 }

--- a/common/src/main/java/net/favouriteless/modopedia/client/screens/books/book_screen_pages/ScreenPage.java
+++ b/common/src/main/java/net/favouriteless/modopedia/client/screens/books/book_screen_pages/ScreenPage.java
@@ -36,6 +36,10 @@ public abstract class ScreenPage {
      */
     public abstract void render(GuiGraphics graphics, PoseStack poseStack, Rectangle dimensions, int mouseX, int mouseY, float partialTick);
 
+    public boolean mouseClicked(Rectangle rectangle, double mouseX, double mouseY, int button) {
+        return false;
+    }
+
     public void hideWidgets() {
         for(AbstractWidget widget : widgets) {
             widget.visible = false;


### PR DESCRIPTION
This adds one method `ScreenPage#mouseClicked(Rectangle, double, double, int)` which `FormattedTextPage` and `LandingScreenPage` override