### PR TITLE
Handle BE and baked model `ModelData` on Neo so dynamic baked models render correctly such as those in Tinkers Construct

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,0 @@
-- ADDED: `FormattedStringBuilder` overloads for links with colours.
-- ADDED: `sort_num` field in category.json for deciding the ordering of categories on the landing page.
-
-- CHANGED: Modopedia books should now show up on JEI and REI searches under the namespace they were created in (e.g. for searching `@enchanted`). This feature currently only works on NeoForge.

--- a/common/src/main/java/net/favouriteless/modopedia/api/multiblock/BEStateMatcher.java
+++ b/common/src/main/java/net/favouriteless/modopedia/api/multiblock/BEStateMatcher.java
@@ -1,0 +1,48 @@
+package net.favouriteless.modopedia.api.multiblock;
+
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+
+import java.util.Optional;
+
+/**
+ * An optional extension to {@link StateMatcher} used to perform post-init operations and/or matching on block entities.
+ */
+public interface BEStateMatcher<T extends BlockEntity> extends StateMatcher {
+
+    /**
+     * @return {@link BlockEntityType} this StateMatcher is matching against. If the BE does not have this type, matching
+     * will be skipped.
+     */
+    BlockEntityType<? extends T> getType();
+
+    /**
+     * @param self {@link BlockEntity} belonging to this StateMatcher.
+     * @param other {@link BlockEntity} being checked against.
+     *
+     * @return True if the BEs match, otherwise false.
+     */
+    boolean matches(T self, T other);
+
+    /**
+     * Called immediately after a {@link BlockEntity} is first created in a {@link MultiblockInstance}. Use this method
+     * to do any setup such as setting fields.
+     */
+    void postInit(T be);
+
+    @SuppressWarnings("unchecked")
+    default Optional<T> cast(BlockEntity be) {
+        return getType() == be.getType() ? Optional.of((T)be) : Optional.empty();
+    }
+
+    default void init(BlockEntity be) {
+        cast(be).ifPresent(this::postInit);
+    }
+
+    default boolean tryMatches(BlockEntity self, BlockEntity other) {
+        Optional<? extends T> _self = cast(self);
+        Optional<? extends T> _other = cast(other);
+        return _self.isPresent() && _other.isPresent() && matches(_self.get(), _other.get());
+    }
+
+}

--- a/common/src/main/java/net/favouriteless/modopedia/api/multiblock/BEStateMatcher.java
+++ b/common/src/main/java/net/favouriteless/modopedia/api/multiblock/BEStateMatcher.java
@@ -22,7 +22,7 @@ public interface BEStateMatcher<T extends BlockEntity> extends StateMatcher {
      *
      * @return True if the BEs match, otherwise false.
      */
-    boolean matches(T self, T other);
+    boolean matches(T other);
 
     /**
      * Called immediately after a {@link BlockEntity} is first created in a {@link MultiblockInstance}. Use this method
@@ -39,10 +39,8 @@ public interface BEStateMatcher<T extends BlockEntity> extends StateMatcher {
         cast(be).ifPresent(this::postInit);
     }
 
-    default boolean tryMatches(BlockEntity self, BlockEntity other) {
-        Optional<? extends T> _self = cast(self);
-        Optional<? extends T> _other = cast(other);
-        return _self.isPresent() && _other.isPresent() && matches(_self.get(), _other.get());
+    default boolean tryMatches(BlockEntity other) {
+        return cast(other).map(this::matches).orElse(false);
     }
 
 }

--- a/common/src/main/java/net/favouriteless/modopedia/api/multiblock/StateMatcher.java
+++ b/common/src/main/java/net/favouriteless/modopedia/api/multiblock/StateMatcher.java
@@ -8,7 +8,6 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
-import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 /**
@@ -28,7 +27,7 @@ public interface StateMatcher {
     }
 
     /**
-     * @return true if the given state matches.
+     * @return True if the given state matches.
      */
     boolean matches(BlockState state);
 
@@ -42,9 +41,4 @@ public interface StateMatcher {
      */
     MapCodec<? extends StateMatcher> typeCodec();
 
-    /**
-     * Initializes the provided BlockEntity however applicable
-     */
-    default void initializeBlockEntity(BlockEntity blockEntity) {
-    }
 }

--- a/common/src/main/java/net/favouriteless/modopedia/api/multiblock/StateMatcher.java
+++ b/common/src/main/java/net/favouriteless/modopedia/api/multiblock/StateMatcher.java
@@ -5,8 +5,10 @@ import com.mojang.serialization.MapCodec;
 import net.favouriteless.modopedia.api.registries.client.StateMatcherRegistry;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 /**
@@ -40,4 +42,9 @@ public interface StateMatcher {
      */
     MapCodec<? extends StateMatcher> typeCodec();
 
+    /**
+     * Initializes the provided BlockEntity however applicable
+     */
+    default void initializeBlockEntity(BlockEntity blockEntity) {
+    }
 }

--- a/common/src/main/java/net/favouriteless/modopedia/client/multiblock/DenseMultiblock.java
+++ b/common/src/main/java/net/favouriteless/modopedia/client/multiblock/DenseMultiblock.java
@@ -41,13 +41,13 @@ public class DenseMultiblock implements Multiblock {
             List<String> layer = pattern.get(y);
 
             if(layer.size() != zSize)
-                throw new IllegalArgumentException("DenseMultiblock must have a rectangle footprint.");
+                throw new IllegalArgumentException("DenseMultiblock must have a rectangular footprint.");
 
             for(int z = 0; z < layer.size(); z++) {
                 String row = layer.get(z);
 
                 if(row.length() != xSize)
-                    throw new IllegalArgumentException("DenseMultiblock must have a rectangle footprint.");
+                    throw new IllegalArgumentException("DenseMultiblock must have a rectangular footprint.");
 
                 for(int x = 0; x < row.length(); x++) {
                     states[PosUtils.posToIndex(x, y, z, xSize, ySize)] = key.get(row.charAt(x));

--- a/common/src/main/java/net/favouriteless/modopedia/client/multiblock/PlacedMultiblock.java
+++ b/common/src/main/java/net/favouriteless/modopedia/client/multiblock/PlacedMultiblock.java
@@ -61,9 +61,8 @@ public class PlacedMultiblock implements MultiblockInstance {
                 beCache.remove(pos);
 
             BlockEntity be = beCache.computeIfAbsent(pos, k -> {
-                StateMatcher matcher = multiblock.getStateMatcher(pos);
                 BlockEntity _be = block.newBlockEntity(pos, state);
-                if(matcher instanceof BEStateMatcher<?> beMatcher)
+                if(multiblock.getStateMatcher(pos) instanceof BEStateMatcher<?> beMatcher)
                     beMatcher.init(_be);
 
                 return _be;

--- a/common/src/main/java/net/favouriteless/modopedia/client/page_components/MultiblockPageComponent.java
+++ b/common/src/main/java/net/favouriteless/modopedia/client/page_components/MultiblockPageComponent.java
@@ -1,7 +1,6 @@
 package net.favouriteless.modopedia.client.page_components;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Axis;
 import net.favouriteless.modopedia.Modopedia;
 import net.favouriteless.modopedia.api.Lookup;
@@ -16,25 +15,20 @@ import net.favouriteless.modopedia.platform.ClientServices;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.RenderType;
-import net.minecraft.client.renderer.block.BlockRenderDispatcher;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
-import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.Vec3;
 
 public class MultiblockPageComponent extends PageComponent {
 
     public static final ResourceLocation ID = Modopedia.id("multiblock");
-    private static final RandomSource RANDOM = RandomSource.createNewThreadLocalInstance();
 
     private MultiblockInstance multiblock;
     private int width;
@@ -120,23 +114,13 @@ public class MultiblockPageComponent extends PageComponent {
     }
 
     protected void renderBlocks(PoseStack pose, MultiBufferSource bufferSource, Vec3i dims, float partialTicks) {
-        BlockRenderDispatcher dispatcher = Minecraft.getInstance().getBlockRenderer();
-        for(BlockPos pos : BlockPos.betweenClosed(0, 0, 0, dims.getX(), dims.getY(), dims.getZ())) {
+	    for(BlockPos pos : BlockPos.betweenClosed(0, 0, 0, dims.getX(), dims.getY(), dims.getZ())) {
             pose.pushPose();
             pose.translate(pos.getX(), pos.getY(), pos.getZ());
 
             BlockState state = multiblock.getBlockState(pos);
             if(state.getRenderShape() == RenderShape.MODEL) {
-                for(RenderType type : ClientServices.PLATFORM.getRenderTypes(multiblock, pos, state)) {
-                    VertexConsumer buffer = bufferSource.getBuffer(type);
-
-                    if(noOffsets) {
-                        Vec3 offset = state.getOffset(multiblock, pos);
-                        pose.translate(-offset.x, -offset.y, -offset.z);
-                    }
-
-                    dispatcher.renderBatched(state, pos, multiblock, pose, buffer, false, RANDOM);
-                }
+                ClientServices.PLATFORM.renderBatched(state, pos, multiblock, pose, bufferSource, false, noOffsets);
             }
 
             pose.popPose();

--- a/common/src/main/java/net/favouriteless/modopedia/platform/services/IClientPlatformHelper.java
+++ b/common/src/main/java/net/favouriteless/modopedia/platform/services/IClientPlatformHelper.java
@@ -1,17 +1,22 @@
 package net.favouriteless.modopedia.platform.services;
 
-import net.minecraft.client.renderer.RenderType;
+import com.mojang.blaze3d.vertex.*;
+
+import net.minecraft.client.renderer.*;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 
 public interface IClientPlatformHelper {
 
-    /**
-     * @return Iterable for every RenderType present in a block's model. On NeoForge, calls NeoForge's
-     * IBakedModelExtension patch. On fabric, just wraps the vanilla method in a list. Necessary because Neo's patch
-     * allows multiple RenderTypes per model.
-     */
-    Iterable<RenderType> getRenderTypes(BlockAndTintGetter level, BlockPos pos, BlockState state);
-
+	/**
+	 * Renders a batched block model. On NeoForge goes through the patched {@link net.minecraft.client.renderer.block.BlockRenderDispatcher#renderBatched BlockRenderDispatcher#renderBatched}
+	 * handling Neos ModelData as well as the additional RenderType arg. On Fabric just goes through the vanilla method like normal.
+	 * <p>
+	 * Needed to handle cases like Tinkers dynamically textured baked models
+	 * </p>
+	 * @param noOffsets If we should negate offsets for blocks like flowers
+	 */
+	void renderBatched(BlockState state, BlockPos pos, BlockAndTintGetter level, PoseStack pose, MultiBufferSource bufferSource, boolean checkSides,
+			boolean noOffsets);
 }

--- a/common/src/main/java/net/favouriteless/modopedia/platform/services/IClientPlatformHelper.java
+++ b/common/src/main/java/net/favouriteless/modopedia/platform/services/IClientPlatformHelper.java
@@ -3,20 +3,19 @@ package net.favouriteless.modopedia.platform.services;
 import com.mojang.blaze3d.vertex.*;
 
 import net.minecraft.client.renderer.*;
+import net.minecraft.client.renderer.block.BlockRenderDispatcher;
 import net.minecraft.core.BlockPos;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 
 public interface IClientPlatformHelper {
 
 	/**
-	 * Renders a batched block model. On NeoForge goes through the patched {@link net.minecraft.client.renderer.block.BlockRenderDispatcher#renderBatched BlockRenderDispatcher#renderBatched}
-	 * handling Neos ModelData as well as the additional RenderType arg. On Fabric just goes through the vanilla method like normal.
-	 * <p>
-	 * Needed to handle cases like Tinkers dynamically textured baked models
-	 * </p>
-	 * @param noOffsets If we should negate offsets for blocks like flowers
+	 * Renders a batched block model via either A.) {@link BlockRenderDispatcher#renderBatched} (fabric) or B.) BE ModelData followed by {@link BlockRenderDispatcher#renderBatched} (NeoForge).
+	 *
+	 * @param noOffsets If true, negate any block offsets (e.g. flowers)
 	 */
-	void renderBatched(BlockState state, BlockPos pos, BlockAndTintGetter level, PoseStack pose, MultiBufferSource bufferSource, boolean checkSides,
-			boolean noOffsets);
+	void renderBatched(BlockState state, BlockPos pos, BlockAndTintGetter level, PoseStack pose, MultiBufferSource bufferSource,
+					   boolean checkSides, boolean noOffsets);
 }

--- a/fabric/src/main/java/net/favouriteless/modopedia/platform/services/FabricClientPlatformHelper.java
+++ b/fabric/src/main/java/net/favouriteless/modopedia/platform/services/FabricClientPlatformHelper.java
@@ -20,7 +20,6 @@ public class FabricClientPlatformHelper implements IClientPlatformHelper {
             boolean checkSides, boolean noOffsets) {
         BlockRenderDispatcher dispatcher = Minecraft.getInstance().getBlockRenderer();
 
-	    // RNG is seeded by the state (model variants and other such things)
         RAND.setSeed(state.getSeed(pos));
 
         if (noOffsets) {
@@ -29,7 +28,6 @@ public class FabricClientPlatformHelper implements IClientPlatformHelper {
         }
 
         VertexConsumer buffer = bufferSource.getBuffer(ItemBlockRenderTypes.getChunkRenderType(state));
-
         dispatcher.renderBatched(state, pos, level, pose, buffer, false, RAND);
     }
 }

--- a/fabric/src/main/java/net/favouriteless/modopedia/platform/services/FabricClientPlatformHelper.java
+++ b/fabric/src/main/java/net/favouriteless/modopedia/platform/services/FabricClientPlatformHelper.java
@@ -1,18 +1,35 @@
 package net.favouriteless.modopedia.platform.services;
 
-import net.minecraft.client.renderer.ItemBlockRenderTypes;
-import net.minecraft.client.renderer.RenderType;
+import com.mojang.blaze3d.vertex.*;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.*;
+import net.minecraft.client.renderer.block.BlockRenderDispatcher;
 import net.minecraft.core.BlockPos;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
-
-import java.util.List;
+import net.minecraft.world.phys.Vec3;
 
 public class FabricClientPlatformHelper implements IClientPlatformHelper {
 
-    @Override
-    public Iterable<RenderType> getRenderTypes(BlockAndTintGetter level, BlockPos pos, BlockState state) {
-        return List.of(ItemBlockRenderTypes.getChunkRenderType(state));
-    }
+    private static final RandomSource RAND = RandomSource.create();
 
+    @Override
+    public void renderBatched(BlockState state, BlockPos pos, BlockAndTintGetter level, PoseStack pose, MultiBufferSource bufferSource,
+            boolean checkSides, boolean noOffsets) {
+        BlockRenderDispatcher dispatcher = Minecraft.getInstance().getBlockRenderer();
+
+	    // RNG is seeded by the state (model variants and other such things)
+        RAND.setSeed(state.getSeed(pos));
+
+        if (noOffsets) {
+            Vec3 offset = state.getOffset(level, pos);
+            pose.translate(-offset.x, -offset.y, -offset.z);
+        }
+
+        VertexConsumer buffer = bufferSource.getBuffer(ItemBlockRenderTypes.getChunkRenderType(state));
+
+        dispatcher.renderBatched(state, pos, level, pose, buffer, false, RAND);
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-    modopedia = "1.1.5"
+    modopedia = "1.1.6"
 
 # Common
     minecraft = "1.21.1"

--- a/neoforge/src/main/java/net/favouriteless/modopedia/platform/services/NeoClientPlatformHelper.java
+++ b/neoforge/src/main/java/net/favouriteless/modopedia/platform/services/NeoClientPlatformHelper.java
@@ -23,17 +23,14 @@ public class NeoClientPlatformHelper implements IClientPlatformHelper {
 			boolean checkSides, boolean noOffsets) {
 		BlockRenderDispatcher dispatcher = Minecraft.getInstance().getBlockRenderer();
 
-		// RNG is seeded by the state (model variants and other such things)
 		RAND.setSeed(state.getSeed(pos));
 
 		ModelData modelData = ModelData.EMPTY;
-		BlockEntity blockEntity = level.getBlockEntity(pos);
-		if (blockEntity != null) {
-			// BE model data first
-			modelData = blockEntity.getModelData();
-		}
+		BlockEntity be = level.getBlockEntity(pos);
+		if(be != null)
+			modelData = be.getModelData();
+
 		BakedModel model = dispatcher.getBlockModel(state);
-		// The model might have model data
 		modelData = model.getModelData(level, pos, state, modelData);
 
 		for (RenderType type : model.getRenderTypes(state, RAND, modelData)) {

--- a/neoforge/src/main/java/net/favouriteless/modopedia/platform/services/NeoClientPlatformHelper.java
+++ b/neoforge/src/main/java/net/favouriteless/modopedia/platform/services/NeoClientPlatformHelper.java
@@ -1,21 +1,50 @@
 package net.favouriteless.modopedia.platform.services;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.*;
+import net.minecraft.client.renderer.block.BlockRenderDispatcher;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
+
+import com.mojang.blaze3d.vertex.*;
 import net.neoforged.neoforge.client.model.data.ModelData;
 
 public class NeoClientPlatformHelper implements IClientPlatformHelper {
 
-    private static final RandomSource RAND = RandomSource.create();
+	private static final RandomSource RAND = RandomSource.create();
 
-    @Override
-    public Iterable<RenderType> getRenderTypes(BlockAndTintGetter level, BlockPos pos, BlockState state) {
-        BakedModel model = Minecraft.getInstance().getBlockRenderer().getBlockModel(state);
-        return model.getRenderTypes(state, RAND, model.getModelData(level, pos, state, ModelData.EMPTY));
-    }
+	@Override
+	public void renderBatched(BlockState state, BlockPos pos, BlockAndTintGetter level, PoseStack pose, MultiBufferSource bufferSource,
+			boolean checkSides, boolean noOffsets) {
+		BlockRenderDispatcher dispatcher = Minecraft.getInstance().getBlockRenderer();
+
+		// RNG is seeded by the state (model variants and other such things)
+		RAND.setSeed(state.getSeed(pos));
+
+		ModelData modelData = ModelData.EMPTY;
+		BlockEntity blockEntity = level.getBlockEntity(pos);
+		if (blockEntity != null) {
+			// BE model data first
+			modelData = blockEntity.getModelData();
+		}
+		BakedModel model = dispatcher.getBlockModel(state);
+		// The model might have model data
+		modelData = model.getModelData(level, pos, state, modelData);
+
+		for (RenderType type : model.getRenderTypes(state, RAND, modelData)) {
+			VertexConsumer buffer = bufferSource.getBuffer(type);
+
+			if (noOffsets) {
+				Vec3 offset = state.getOffset(level, pos);
+				pose.translate(-offset.x, -offset.y, -offset.z);
+			}
+
+			dispatcher.renderBatched(state, pos, level, pose, buffer, checkSides, RAND, modelData, type);
+		}
+	}
 }


### PR DESCRIPTION
BlockEntitys can supply ModelData in NeoForge to baked models allowing non-standard features such as dynamically textured baked models (Tinkers does this).

Draft as I think the BE initialization method (`StateMatcher#initializeBlockEntity`) needs some more thought